### PR TITLE
Sls new

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 samples
+test

--- a/apis/sls-2014-11-18.json
+++ b/apis/sls-2014-11-18.json
@@ -88,7 +88,7 @@
             "members": {
             }
           },
-          "RequestId": {
+          "request_id": {
             "location": "header",
             "name": "x-sls-requestid"
           }
@@ -122,7 +122,7 @@
             "members": {
             }
           },
-          "RequestId": {
+          "request_id": {
             "location": "header",
             "name": "x-sls-requestid"
           }
@@ -163,7 +163,10 @@
       "output":{
         "type": "structure",
         "members": {
-
+          "request_id": {
+            "location": "header",
+            "name": "x-sls-requestid"
+          }
         }
       }
     },
@@ -211,7 +214,10 @@
       "output":{
         "type": "structure",
         "members": {
-
+          "request_id": {
+            "location": "header",
+            "name": "x-sls-requestid"
+          }
         }
       }
     },
@@ -276,7 +282,10 @@
       "output":{
         "type": "structure",
         "members": {
-
+          "request_id": {
+            "location": "header",
+            "name": "x-sls-requestid"
+          }
         }
       }
     }

--- a/lib/services/sls.js
+++ b/lib/services/sls.js
@@ -50,30 +50,42 @@ ALY.SLS = ALY.Service.defineService('sls', ['2014-11-18'], {
         request.addListener('extractError', this.extractError);
         request.addListener('extractData', this.extractData);
 
-        request.addListener('afterBuild', function (req) {
-            //Host in request.header 
-            req.httpRequest.headers['Host'] = req.params['projectName']
-            +'.'+req.httpRequest.endpoint.hostname;
-            //头中的 projectName 不需要
-            delete req.httpRequest.headers['projectName'];
-        });
+        //request.addListener('afterBuild', function (req) {
+        //    //Host in request.header
+        //    console.log(req.httpRequest.headers['projectName'], req.params['projectName']);
+        //
+        //    req.httpRequest.headers['Host'] = req.params['projectName']
+        //       +'.'+req.httpRequest.endpoint.hostname;
+        //    //头中的 projectName 不需要
+        //    delete req.httpRequest.headers['projectName'];
+        //});
 
     },
 
     populateURI: function populateURI(req) {
         var hostname = req.httpRequest.endpoint.hostname;
+
         var projectName = req.params['projectName'];
+        var host = projectName+'.'+ hostname;
+
 
         if(!/^[0-9.]+$/.test(hostname)){
-            //不是ip,  是域名
+            //不是ip,  是域名, 则需要拼接project名
             var protocol = req.httpRequest.endpoint.protocol;
             var port = req.httpRequest.endpoint.port;
-            var host = req.params['projectName']+'.'+ hostname;
+
+            //real endpoint
             var endpointObj = parseURL(protocol+'//'+host+':'+port);
 
             ALY.util.update(req.httpRequest, {endpoint: endpointObj });
-            ALY.util.update(req.service, {endpoint: endpointObj });
+           // ALY.util.update(req.service, {endpoint: endpointObj });
         }
+
+        //final host， 不管是ip还是域名，都要拼接project名
+        req.httpRequest.headers['Host'] = host;
+
+        //头中的 projectName 不需要
+        delete req.httpRequest.headers['projectName'];
     },
 
     addContentType: function addContentType(req) {
@@ -126,7 +138,7 @@ ALY.SLS = ALY.Service.defineService('sls', ['2014-11-18'], {
 
             var pb = protoBufferEncode('LogGroup', logGroup);
 
-            if(pb.length>5*1024*1024){
+            if(pb.length>3*1024*1024){
                 throw ALY.util.error(new Error(), {
                     code: 'ContentError', message: 'Logitems size exceed 5MB', retryable: false
                 });
@@ -195,13 +207,10 @@ ALY.SLS = ALY.Service.defineService('sls', ['2014-11-18'], {
     },
 
     retryableError: function retryableError(error, request) {
-        if (request.operation == 'completeMultipartUpload' &&
-            error.statusCode === 200) {
-            return true;
-        } else {
-            var _super = ALY.Service.prototype.retryableError;
-            return _super.call(this, error, request);
-        }
+
+        var _super = ALY.Service.prototype.retryableError;
+        return _super.call(this, error, request);
+
     },
 
     extractData: function extractData(resp) {
@@ -212,11 +221,25 @@ ALY.SLS = ALY.Service.defineService('sls', ['2014-11-18'], {
     },
 
     extractError: function extractError(resp) {
+        var headers = resp.httpResponse.headers;
+
         var body = resp.httpResponse.body;
+        var data = body.toString();
+
+        try{ 
+            data = JSON.parse(data);
+            if(data){
+                data.RequestId = headers['x-sls-requestid'] || null;
+            }
+        }catch(e){
+
+        }
+
         resp.error = ALY.util.error(new Error(), {
             code: resp.httpResponse.statusCode,
             message: body.toString(),
-            headers: resp.httpResponse.headers
+            error: data,
+            headers: headers
         });
     }
 

--- a/lib/services/sls.js
+++ b/lib/services/sls.js
@@ -201,7 +201,7 @@ ALY.SLS = ALY.Service.defineService('sls', ['2014-11-18'], {
 
 
     successfulResponse: function successfulResponse(resp) {
-        var req = resp.request;
+        //var req = resp.request;
         var httpResponse = resp.httpResponse;
         return httpResponse.statusCode < 300;
     },
@@ -216,31 +216,34 @@ ALY.SLS = ALY.Service.defineService('sls', ['2014-11-18'], {
     extractData: function extractData(resp) {
         var reqId = resp.httpResponse.headers['x-sls-requestid'];
         if (reqId) {
-            resp.data.RequestId = reqId;
+            resp.data.request_id = reqId;
         }
+        resp.data.headers = resp.httpResponse.headers;
+
+        //去掉RequestId
+        delete resp.data.RequestId;
     },
 
     extractError: function extractError(resp) {
         var headers = resp.httpResponse.headers;
 
         var body = resp.httpResponse.body;
-        var data = body.toString();
+        var error = body.toString();
 
-        try{ 
-            data = JSON.parse(data);
-            if(data){
-                data.RequestId = headers['x-sls-requestid'] || null;
-            }
+        try{
+            error = JSON.parse(error);
         }catch(e){
-
+            error = {};
         }
 
-        resp.error = ALY.util.error(new Error(), {
+        error = ALY.util.update(error, {
+            request_id : headers['x-sls-requestid'] || null,
             code: resp.httpResponse.statusCode,
             message: body.toString(),
-            error: data,
             headers: headers
         });
+
+        resp.error = ALY.util.error(new Error(), error);
     }
 
 });

--- a/package.json
+++ b/package.json
@@ -14,8 +14,10 @@
     "cucumber": "",
     "jasmine-node": "",
     "jshint": "",
+    "mocha": "~2.1.0",
     "repl.history": "",
-    "semver": ""
+    "semver": "",
+    "should": "~4.6.3"
   },
   "dependencies": {
     "node_memcached": "1.1.3",
@@ -39,5 +41,7 @@
     "mail": ""
   },
   "keywords": [],
-  "scripts": {}
+  "scripts": {
+    "test": "mocha test"
+  }
 }

--- a/samples/sls/GetHistograms.js
+++ b/samples/sls/GetHistograms.js
@@ -8,9 +8,11 @@ var logStoreName = "logstore_name1";
 var to = Math.floor(new Date().getTime() / 1000);
 var from = to - 900; //15min
 
-sls.getHistogram(projectName, logStoreName, {
+sls.getHistogram({
 
-    //必选字段
+    //必选字段 
+    projectName: projectName,
+    logStoreName: logStoreName,
     from: from, //开始时间(精度为秒,从 1970-1-1 00:00:00 UTC 计算起的秒数)
     to: to,    //结束时间(精度为秒,从 1970-1-1 00:00:00 UTC 计算起的秒数)
 

--- a/samples/sls/GetLogs.js
+++ b/samples/sls/GetLogs.js
@@ -7,9 +7,11 @@ var projectName = "project_name1";
 var logStoreName = "logstore_name1";
 var to = Math.floor(new Date().getTime() / 1000);
 var from = to - 900; //15min
-sls.getLogs(projectName, logStoreName, {
+sls.getLogs({
 
-    //必选字段
+    //必选字段 
+    projectName: projectName,
+    logStoreName: logStoreName,
     from: from, //开始时间(精度为秒,从 1970-1-1 00:00:00 UTC 计算起的秒数)
     to: to,    //结束时间(精度为秒,从 1970-1-1 00:00:00 UTC 计算起的秒数)
 

--- a/samples/sls/ListLogStores.js
+++ b/samples/sls/ListLogStores.js
@@ -5,7 +5,10 @@ var sls = require('./sls');
 // -------------------------------
 var projectName = "project_name1";
 
-sls.listLogStores(projectName, function (err, data) {
+sls.listLogStores({
+  //必选字段
+    projectName: projectName 
+}, function (err, data) {
 
     if (err) {
         console.log('error:', err);

--- a/samples/sls/ListTopics.js
+++ b/samples/sls/ListTopics.js
@@ -6,7 +6,11 @@ var sls = require('./sls');
 var projectName = "project_name1";
 var logStoreName = "logstore_name1";
 
-sls.listTopics(projectName, logStoreName, {
+sls.listTopics({
+    //必选字段
+    projectName: projectName,
+    logStoreName: logStoreName,
+    
     //token: '', //可选参数，从某个 topic 开始列出,按照字典序,默认为空 6
     line: 100    //可选参数，读取的行数,默认值为 100;范围 0-100
 },function (err, data) {

--- a/samples/sls/sls.js
+++ b/samples/sls/sls.js
@@ -8,6 +8,7 @@ var sls = new ALY.SLS({
     // 杭州：http://cn-hangzhou.sls.aliyuncs.com
     // 青岛：http://cn-qingdao.sls.aliyuncs.com
     endpoint: 'http://cn-hangzhou.sls.aliyuncs.com',
+
     // 这是 sls sdk 目前支持最新的 api 版本, 不需要修改
     apiVersion: '2014-11-18'
 });

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,28 @@
+aliyun-sdk test
+-----------------------
+
+### 1. require mocha & should
+
+```bash
+npm i mocha should --save-dev
+```
+
+### 2. how to run?
+
+#### (1) config
+
+fill configurations in config.js
+
+#### (2) run single module, for example: sls
+
+```bash
+cd aliyun-sdk-js/test/sls
+mocha index
+```
+
+#### (3) run all
+
+```bash
+cd aliyun-sdk-js
+npm test  #or mocha test
+```

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,4 @@
+
+//run with mocha
+
+require('./sls');

--- a/test/sls/config.js
+++ b/test/sls/config.js
@@ -1,0 +1,14 @@
+var conf = {
+    accessKeyId: '',
+    secretAccessKey: '',
+    endpoint: 'http://cn-hangzhou.sls.aliyuncs.com',
+    projectName: '',
+    logStoreName: ''
+};
+
+try{
+    module.exports = require('../configuration/sls_config');
+}catch(e){
+    //if '../configuration/config' does not exists
+    module.exports = conf;
+}

--- a/test/sls/index.js
+++ b/test/sls/index.js
@@ -1,0 +1,204 @@
+var ALY = require('../../index.js');
+var config = require('./config');
+var should = require('should');
+
+var sls = new ALY.SLS({
+    accessKeyId: config.accessKeyId,
+    secretAccessKey: config.secretAccessKey,
+    endpoint: config.endpoint,
+    apiVersion: '2014-11-18'
+});
+
+var projectName = config.projectName;
+var logStoreName = config.logStoreName;
+var TOPIC = 'VV';
+
+
+describe('SLS Function Test', function(){
+
+    this.timeout(60000);
+
+    describe('PutLogs', function(){
+
+        it('should put logs success, loop 10 times', function(done){
+
+            function loopPutLogs(fn){
+                var logs = [];
+                var nowT = Math.floor(new Date().getTime()/1000);
+
+                for(var i=101;i>0;i--){
+                    logs.push({
+                        time:  nowT-i,
+                        contents: [{
+                            key: 'a',
+                            value: '1'
+                        },{
+                            key: 'b',
+                            value: '2'
+                        },{
+                            key: 'c',
+                            value: ''+Math.random()
+                        }]
+                    });
+                }
+
+                var logGroup = {
+                    logs : logs,
+                    topic: TOPIC,
+                    source: '127.0.0.1'
+                };
+
+                sls.putLogs({
+                    projectName: projectName,
+                    logStoreName: logStoreName,
+                    logGroup: logGroup
+                }, function (err, data) {
+                    if(err){
+                        console.log(err);
+                    }
+
+                    should(err === null).be.true;
+                    data.should.have.property('RequestId');
+
+                    fn();
+                });
+            };
+
+
+            var len = 10;
+            var _dig = function(){
+                console.log('\tloop put logs,',len)
+                loopPutLogs(function(){
+                    len--;
+                    if(len<=0){
+                        done();
+                        return;
+                    }
+                    setTimeout(function(){
+                        _dig();
+                    });
+                });
+            };
+            _dig();
+
+        });
+
+
+        it('should put logs failed with not exists logstore', function(done){
+
+            var logGroup = {
+                logs : [{
+                    time:  Math.floor(new Date().getTime()/1000),
+                    contents: [{
+                        key: 'a',
+                        value: '1'
+                    },{
+                        key: 'a',
+                        value: '2'
+                    },{
+                        key: 'a',
+                        value: '3'
+                    }]
+                }],
+                topic: TOPIC,
+                source: '127.0.0.1'
+            };
+
+            sls.putLogs({
+                projectName: projectName,
+                logStoreName: 'not_exists_logstore',
+                logGroup: logGroup
+            }, function (err, data) {
+                err.code.should.be.exactly(404);
+                err.error.should.have.property('error_code','SLSLogStoreNotExist');
+                err.error.should.have.property('RequestId');
+                done();
+            });
+        });
+    });
+
+    describe('ListLogStores', function(){
+
+        it('should list logstores success', function(done){
+
+            sls.listLogStores({
+                projectName: projectName
+            }, function(err, data){
+
+                should(err===null).be.true;
+                data.count.should.be.above(0);
+                data.logstores.should.containEql('laok');
+
+                done();
+            });
+        });
+    });
+
+    describe('ListTopics', function(){
+
+        it('should list topics success', function(done){
+
+            sls.listTopics({
+                projectName: projectName,
+                logStoreName: logStoreName
+            }, function(err, data){
+
+                should(err===null).be.true;
+                data.count.should.be.above(0);
+                data.topics.should.containEql(TOPIC);
+
+                done();
+            });
+        });
+    });
+
+    describe('GetHistograms', function(){
+
+        it('should get histograms success', function(done){
+            var to =Math.floor(new Date().getTime()/1000);
+            var from = to-1000;
+
+            sls.getHistograms({
+                projectName: projectName,
+                logStoreName: logStoreName,
+                from: from,
+                to: to,
+                topic: TOPIC
+            }, function(err, data){
+
+                should(err===null).be.true;
+                data.count.should.be.above(1);
+                data.histograms.should.be.an.Array;
+
+
+                data.should.have.properties(['progress','RequestId']);
+
+                done();
+            });
+        });
+    });
+
+
+    describe('GetLogs', function(){
+
+        it('should get logs success', function(done){
+            var to =Math.floor(new Date().getTime()/1000);
+            var from = to-1000;
+
+            sls.getLogs({
+                projectName: projectName,
+                logStoreName: logStoreName,
+                from: from,
+                to: to,
+                topic: TOPIC,
+                offset: 0,
+                line: 2
+            }, function(err, data){
+
+                should(err===null).be.true;
+                data.count.should.be.below(3);
+                done();
+            });
+        });
+    });
+});

--- a/test/sls/index.js
+++ b/test/sls/index.js
@@ -58,7 +58,7 @@ describe('SLS Function Test', function(){
                     }
 
                     should(err === null).be.true;
-                    data.should.have.property('RequestId');
+                    data.should.have.properties(['request_id','headers']);
 
                     fn();
                 });
@@ -84,7 +84,7 @@ describe('SLS Function Test', function(){
         });
 
 
-        it('should put logs failed with not exists logstore', function(done){
+        it('should put logs failed with logstore does not exists ', function(done){
 
             var logGroup = {
                 logs : [{
@@ -109,9 +109,10 @@ describe('SLS Function Test', function(){
                 logStoreName: 'not_exists_logstore',
                 logGroup: logGroup
             }, function (err, data) {
+
                 err.code.should.be.exactly(404);
-                err.error.should.have.property('error_code','SLSLogStoreNotExist');
-                err.error.should.have.property('RequestId');
+                err.should.have.property('error_code','SLSLogStoreNotExist');
+                err.should.have.properties(['request_id','headers','error_message']);
                 done();
             });
         });
@@ -127,7 +128,8 @@ describe('SLS Function Test', function(){
 
                 should(err===null).be.true;
                 data.count.should.be.above(0);
-                data.logstores.should.containEql('laok');
+                data.logstores.should.containEql(logStoreName);
+                data.should.have.properties(['request_id','headers']);
 
                 done();
             });
@@ -146,6 +148,7 @@ describe('SLS Function Test', function(){
                 should(err===null).be.true;
                 data.count.should.be.above(0);
                 data.topics.should.containEql(TOPIC);
+                data.should.have.properties(['request_id','headers']);
 
                 done();
             });
@@ -170,8 +173,7 @@ describe('SLS Function Test', function(){
                 data.count.should.be.above(1);
                 data.histograms.should.be.an.Array;
 
-
-                data.should.have.properties(['progress','RequestId']);
+                data.should.have.properties(['progress','request_id','headers']);
 
                 done();
             });
@@ -197,6 +199,29 @@ describe('SLS Function Test', function(){
 
                 should(err===null).be.true;
                 data.count.should.be.below(3);
+
+                data.should.have.properties(['logs','request_id','headers']);
+
+                done();
+            });
+        });
+        it('should get logs failed with logstore does not exists ', function(done){
+            var to =Math.floor(new Date().getTime()/1000);
+            var from = to-1000;
+
+            sls.getLogs({
+                projectName: projectName,
+                logStoreName: 'xxoo_not_exists_aslds',
+                from: from,
+                to: to,
+                topic: TOPIC,
+                offset: 0,
+                line: 2
+            }, function(err, data){
+
+                err.code.should.be.exactly(404);
+                err.should.have.property('error_code','SLSLogStoreNotExist');
+                err.should.have.properties(['request_id','headers','error_message']);
                 done();
             });
         });


### PR DESCRIPTION
1. 去掉 afterBuild 的监听，统一放到populateURI 方法处理。
2. putLogs 每次不能超过5MB改为3MB。
3. 报错的时候增加一个key： error。
4. 修复 sample 中，有些调用方式不正确的问题。
5. 增加 FT。


error格式样例：
{ message: '{"error_code":"SLSLogStoreNotExist","error_message":"logstore xxoo_not_exists_aslds not exist"}\n',
  error_code: 'SLSLogStoreNotExist',
  error_message: 'logstore xxoo_not_exists_aslds not exist',
  request_id: '54D33044AB9AC49D2E1D2274',
  code: 404,
  headers: { ... }
}

data格式样例(getLogs返回):
{ request_id: '54D33150AB9AC4932E1D20D3',
  count: 2,
  logs: 
   [ { __source__: '127.0.0.1',
       __time__: '1423125883',
       a: '1',
       b: '2',
       c: '0.9211293577682227' },
     { __source__: '127.0.0.1',
       __time__: '1423125884',
       a: '1',
       b: '2',
       c: '0.9340025323908776' } ],
  progress: 'Complete',
  headers: { ... }
}
