### PR TITLE
低版本node不支持zlib的inflateSync方法，改成使用不压缩的方式读数据

### DIFF
--- a/lib/services/sls.js
+++ b/lib/services/sls.js
@@ -182,7 +182,7 @@ ALY.SLS = ALY.Service.defineService('sls', ['2015-06-01'], {
     else if (req.operation == "batchGetLogs")
     {
         headers["Accept"] = "application/x-protobuf";
-        headers["Accept-Encoding"] = "deflate";
+        headers["Accept-Encoding"] = "";
         done();
     }
     else{
@@ -253,15 +253,16 @@ ALY.SLS = ALY.Service.defineService('sls', ['2015-06-01'], {
     }
     resp.data.headers = resp.httpResponse.headers;
 
-     if (resp.httpResponse.headers['x-log-compresstype'] == "deflate")
-     { 
-         var protoBufferDecode= function(name, data) {
+    var protoBufferDecode= function(name, data) {
                 po_protobuf.init({
                   encoderProtos: protos,
                   decoderProtos: protos
                 });
                 return po_protobuf.decode(name, data);
               };
+
+     if (resp.httpResponse.headers['x-log-compresstype'] == "deflate")
+     { 
          if(body.logGroupListBuf != null)
          {
              uncompressed = zlib.inflateSync(body.logGroupListBuf);
@@ -275,7 +276,13 @@ ALY.SLS = ALY.Service.defineService('sls', ['2015-06-01'], {
      }
      else
      {
-         resp.data.body= body;
+         if(resp.data.headers['content-type']== 'application/x-protobuf')
+         {
+             var pb = protoBufferDecode("LogGroupList",body.logGroupListBuf);
+             resp.data.body = pb;
+         }
+         else
+             resp.data.body = body;
      }
   },
 


### PR DESCRIPTION
低版本node不支持zlib的inflateSync方法，改成使用不压缩的方式读数据