### PR TITLE
add sts api: get-caller-identity

### DIFF
--- a/apis/sts-2015-04-01.json
+++ b/apis/sts-2015-04-01.json
@@ -1,43 +1,59 @@
 {
-  "format": "pop",
-  "apiVersion": "2015-04-01",
-  "checksumFormat": "md5",
-  "endpointPrefix": "sts",
-  "serviceAbbreviation": "STS",
-  "serviceFullName": "Aliyun STS",
-  "signatureVersion": "pop",
-  "timestampFormat": "top",
-  "xmlnamespace": "",
-  "operations": {
-    "assumeRole": {
-      "name": "AssumeRole",
-      "http": {
-        "method": "POST",
-        "uri": "/"
-      },
-      "input": {
-        "type": "structure",
-        "members": {
-          "Action": {
-            "required": true,
-            "default": "AssumeRole"
-          },
-          "DurationSeconds": {
-            "type": "integer"
-          },
-          "Policy": {
-            "type": "string"
-          },
-          "RoleArn": {
-            "required": true,
-            "type": "string"
-          },
-          "RoleSessionName": {
-            "required": true,
-            "type": "string"
-          }
+    "format":"pop",
+    "apiVersion":"2015-04-01",
+    "checksumFormat":"md5",
+    "endpointPrefix":"sts",
+    "serviceAbbreviation":"STS",
+    "serviceFullName":"Aliyun STS",
+    "signatureVersion":"pop",
+    "timestampFormat":"top",
+    "xmlnamespace":"",
+    "operations":{
+        "assumeRole":{
+            "name":"AssumeRole",
+            "http":{
+                "method":"POST",
+                "uri":"/"
+            },
+            "input":{
+                "type":"structure",
+                "members":{
+                    "Action":{
+                        "required":true,
+                        "default":"AssumeRole"
+                    },
+                    "DurationSeconds":{
+                        "type":"integer"
+                    },
+                    "Policy":{
+                        "type":"string"
+                    },
+                    "RoleArn":{
+                        "required":true,
+                        "type":"string"
+                    },
+                    "RoleSessionName":{
+                        "required":true,
+                        "type":"string"
+                    }
+                }
+            }
+        },
+        "getCallerIdentity":{
+            "name":"AssumeRole",
+            "http":{
+                "method":"POST",
+                "uri":"/"
+            },
+            "input":{
+                "type":"structure",
+                "members":{
+                    "Action":{
+                        "required":true,
+                        "default":"GetCallerIdentity"
+                    }
+                }
+            }
         }
-      }
     }
-  }
 }

--- a/samples/sts/test.js
+++ b/samples/sts/test.js
@@ -21,3 +21,10 @@ sts.assumeRole({
 }, function (err, res) {
   console.log(err, res);
 });
+
+//构造GetCallerIdentity请求
+sts.getCallerIdentity({
+    Action : 'GetCallerIdentity'
+}, function (err, res) {
+    console.log(err, res);
+});


### PR DESCRIPTION
为STS新增一个API：GetCallerIdentity，该API可以返回当前调用者身份

输入参数：无

返回样例：
```
{
    "AccountId": "1140635653649189",
    "Arn": "acs:ram::1140635653649189:user/boyang",
    "RequestId": "9A684E30-5AF8-4CE7-9B8D-4BD237282CF2",
    "UserId": "222806035655679708"
}
```