### PR TITLE
响应头中暴露所有x-oss-*字段

### DIFF
--- a/lib/services/oss.js
+++ b/lib/services/oss.js
@@ -118,6 +118,19 @@ ALY.OSS = ALY.Service.defineService('oss', ['2013-10-15'], {
       }
     }
 
+    for(var k in resp.httpResponse.headers){
+      if(k.indexOf('x-oss-')==0){
+        var arr = k.substring('x-oss-'.length).split('-');
+        for(var i=0;i<arr.length;i++){
+          arr[i] = arr[i][0].toUpperCase()+arr[i].substring(1);
+        }
+        resp.data[arr.join('')] = resp.httpResponse.headers[k];
+      }
+      else if(k=='content-md5'){
+        resp.data['ContentMD5'] = resp.httpResponse.headers['content-md5'];
+      }
+    }
+
     // extract request id
     resp.data.RequestId = resp.httpResponse.headers['x-oss-request-id'] ||
         resp.httpResponse.headers['x-oss-requestid'];


### PR DESCRIPTION
暴露所有x-oss-*字段，
以便下载文件后，可以通过请求头中的x-oss-hash-crc64ecma验证文件完整性：
https://help.aliyun.com/document_detail/43394.html