### PR TITLE
add CDN SetDomainServerCertificate method CertName & Region params

### DIFF
--- a/apis/cdn-2014-11-11.json
+++ b/apis/cdn-2014-11-11.json
@@ -2294,6 +2294,12 @@
           "SecurityToken": {
             "type": "string"
           },
+          "CertName": {
+            "type": "string"
+          },
+          "Region": {
+            "type": "string"
+          },
           "DomainName": {
             "required": true,
             "type": "string"


### PR DESCRIPTION
补了下 CDN 里面设置证书时最新的参数。(旧的没有删除

[https://help.aliyun.com/document_detail/45014.html?spm=a2c4g.11186623.6.676.zUn8Vq](https://help.aliyun.com/document_detail/45014.html?spm=a2c4g.11186623.6.676.zUn8Vq)