### PR TITLE
fix：Fix putLogs API validation does not support LogTags field

### DIFF
--- a/apis/sls-2015-06-01.json
+++ b/apis/sls-2015-06-01.json
@@ -170,6 +170,23 @@
               "source": {
                 "type": "string",
                 "required": false
+              },
+              "LogTags": {
+                "type": "list",
+                "required": false,
+                "members": {
+                  "type":"structure",
+                  "members": {
+                    "Key": {
+                      "type": "string",
+                      "required": true
+                    },
+                    "Value": {
+                      "type": "string",
+                      "required": true
+                    }
+                  }
+                }
               }
             }
           }
@@ -1095,7 +1112,7 @@
               "cu":{
                   "type":"integer"
               }
-              
+
           }
         }
       }


### PR DESCRIPTION
Fix sls.putLogs API validation does not support LogTags field

```js
 const param = {
    projectName,
    logStoreName: logstoreName,
    logGroup: { // 必选，写入的日志数据。
      logs: [
        {
          time: Math.floor(new Date().getTime() / 1000),
          contents: [
            { key: 'a1', value: '1' },
            { key: 'a2', value: '2' },
            { key: 'a3', value: '3' },
          ],
        },
      ],
      topic: 'vv',
      source: '127.0.0.1',
      // 本身api 支持，api input 检验没更新
      LogTags: [
        {
          Key: 'nick12',
          Value: 'mind',
        },
      ],
    },
  };

  sls.putLogs(param, (err, data) => {
    if (err) {
      console.error('error:', err);
    } else {
      console.log('写入日志成功', data);
    }
  });

```